### PR TITLE
bug fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,9 @@ fi
 
 conan install -s build_type=$BUILD_TYPE "${CONAN_DIR}"
 
-cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+echo "${CONAN_DIR}/conan_toolchain.cmake"
+
+cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+         -DCMAKE_TOOLCHAIN_FILE="${BUILD_DIR}conan_toolchain.cmake"
 cmake --build "$BUILD_DIR"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(GTest REQUIRED)
+set(PROJECT_NAME cpp-algorithm-design.test)
 
 set(SOURCE  
         main.cpp
@@ -6,7 +7,7 @@ set(SOURCE
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../bin)
 
-add_executable(cpp-algorithm-design ${SOURCE})
+add_executable(${PROJECT_NAME} ${SOURCE})
 
 target_link_libraries(${PROJECT_NAME} GTest::gtest_main)
 target_link_libraries(${PROJECT_NAME} GTest::gtest)


### PR DESCRIPTION
append -DCMAKE_TOOLCHAIN_FILE="${BUILD_DIR}conan_toolchain.cmake" build option into build.sh script.
before this option, linking time error was raised by make tool